### PR TITLE
Document UART

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ USEMODULE += vfs
 USEMODULE += prng_sha256prng
 USEMODULE += tiny_strerror
 FEATURES_REQUIRED += periph_adc
+FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_i2c
 FEATURES_REQUIRED += periph_spi
-FEATURES_REQUIRED += periph_gpio
 
 USEPKG += nimble
 

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ FEATURES_REQUIRED += periph_adc
 FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_i2c
 FEATURES_REQUIRED += periph_spi
+FEATURES_REQUIRED += periph_uart
 
 USEPKG += nimble
 


### PR DESCRIPTION
Right now there are no high-level wrappers, but enabling the periph feature at least ensures that the macro_UART_DEV macro is documented.